### PR TITLE
Fix issue #1 - Implement method `focus` in `MarkdownEditor`

### DIFF
--- a/lib/markdown-editor.cjsx
+++ b/lib/markdown-editor.cjsx
@@ -60,6 +60,9 @@ class MarkdownEditor extends React.Component
     dialog = require('remote').require('dialog')
     dialog.showErrorBox('Markdown Conversion Failed', error.toString())
 
+  focus: =>
+    this.focusEditor()
+
   _renderIntoIframe: (markdown)=>
     html = @_markdownToHtml(markdown)
     doc = React.findDOMNode(@refs.previewFrame).contentDocument


### PR DESCRIPTION
This is a simple fix for issue #1.

We were getting an error like this before:

> Uncaught Error: MarkdownEditor must implement methodfocuswhen registering for {"role":"Composer:Editor"}

This should fix it.
