### PR TITLE
Made extension use React exposed by `nylas-exports`

### DIFF
--- a/lib/markdown-editor.cjsx
+++ b/lib/markdown-editor.cjsx
@@ -1,8 +1,9 @@
 _ = require 'underscore'
 Utils = require './utils'
 SimpleMDE = require 'simplemde'
-React = require 'react'
-ReactDOM = require 'react-dom'
+nylas = require 'nylas-exports'
+React = nylas.React
+ReactDOM = nylas.ReactDOM
 
 # Keep a file-scope variable containing the contents of the markdown stylesheet.
 # This will be embedded in the markdown preview iFrame, as well as the email body.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "simplemde": "jstejada/simplemde-markdown-editor",
-    "marked": "^0.3"
+    "marked": "^0.3",
+    "underscore": "^1.8"
   }
 }


### PR DESCRIPTION
Fixes #15 and #9.

N1 packages should use the React object exposed by `nylas-exports` to prevent the errors as described in #15.

Additionally, since this package uses underscore.js, it should be a dependency. It might be a good idea to one day remove the dependency though. IMO it's a pretty heavy package to include in an extension, and it is only used for the `_.defer()` function, which I don't think is required.
